### PR TITLE
docs: fix vitest install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ runner.
 If you haven't done so already, add vitest to your project using Qwik CLI:
 
 ```shell
-npm qwik add vitest
+npm run qwik add vitest
 ```
 
 After that, we need to configure Vitest so it can run your tests.


### PR DESCRIPTION
`npm qwik add vitest` won't work. Needs `npm run` or `npx qwik`.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
- [ ] Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist:

- [x] My code follows
  the [developer guidelines of this project](https://github.com/ianlet/qwik-testing-library/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the docs
- [ ] Added new tests to cover the fix / functionality