### PR TITLE
feat: add renderHook for testing hooks in isolation (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ src="https://raw.githubusercontent.com/ianlet/qwik-testing-library/main/high-vol
 - [Setup](#setup)
 - [Examples](#examples)
     - [Qwikstart](#qwikstart)
+    - [Testing Hooks (experimental)](#testing-hooks-experimental)
     - [Mocking Component Callbacks (experimental)](#mocking-component-callbacks-experimental)
     - [Qwik City - `server$` calls](#qwik-city---server-calls)
 - [Gotchas](#gotchas)
@@ -262,6 +263,109 @@ describe("<Counter />", () => {
     expect(await screen.findByText(/count:2/)).toBeInTheDocument();
   });
 })
+```
+
+### Testing Hooks (experimental)
+
+> [!WARNING]
+> This feature is under a testing phase and thus experimental.
+> Its API may change in the future, so use it at your own risk.
+
+`renderHook` lets you test custom hooks in isolation, without building a wrapper component by hand.
+This is especially useful for library authors who need to battle-test the hooks they provide to their users.
+
+```tsx
+// use-counter.tsx
+
+import { $, useSignal } from "@builder.io/qwik";
+
+export function useCounter(initial = 0) {
+  const count = useSignal(initial);
+  const increment$ = $(() => count.value++);
+
+  return { count, increment$ };
+}
+```
+
+```tsx
+// use-counter.spec.tsx
+
+import { renderHook } from "@noma.to/qwik-testing-library";
+import { useCounter } from "./use-counter";
+
+describe("useCounter", () => {
+  it("should start at 0", async () => {
+    const { result } = await renderHook(useCounter);
+
+    expect(result.count.value).toBe(0);
+  });
+
+  it("should increment", async () => {
+    const { result } = await renderHook(useCounter);
+
+    await result.increment$();
+
+    expect(result.count.value).toBe(1);
+  });
+});
+```
+
+The `result` is the direct return value of your hook callback. Because Qwik signals are stable reactive
+references, you can read and mutate them directly — no `.current` wrapper needed.
+
+#### ESLint `qwik/use-method-usage`
+
+The Qwik ESLint plugin only allows `use*` calls inside `component$` or `use*`-named functions.
+This is a known limitation — a discussion is in progress with the Qwik team to relax their ESLint rule.
+In the meantime, when you need to pass arguments to your hook, wrap it in a `use*`-named function to stay lint-clean:
+
+```tsx
+// passing the hook by reference — lint-clean
+const { result } = await renderHook(useCounter);
+
+// passing arguments — extract a use*-named function
+function useCounterFrom10() {
+  return useCounter(10);
+}
+const { result } = await renderHook(useCounterFrom10);
+```
+
+#### Providing Context
+
+If your hook depends on context, use the `wrapper` option to provide it:
+
+```tsx
+import { renderHook } from "@noma.to/qwik-testing-library";
+import { component$, createContextId, useContextProvider, useStore, Slot } from "@builder.io/qwik";
+import { useTheme } from "./use-theme";
+
+const ThemeContext = createContextId<{ mode: string }>("theme");
+
+const ThemeProvider = component$(() => {
+  useContextProvider(ThemeContext, useStore({ mode: "dark" }));
+  return <Slot />;
+});
+
+it("should read theme from context", async () => {
+  const { result } = await renderHook(useTheme, {
+    wrapper: ThemeProvider,
+  });
+
+  expect(result.mode).toBe("dark");
+});
+```
+
+#### Cleanup
+
+`renderHook` integrates with automatic cleanup, just like `render`.
+You can also call `unmount()` manually if needed:
+
+```tsx
+const { result, unmount } = await renderHook(useCounter);
+
+// ... assertions ...
+
+unmount();
 ```
 
 ### Mocking Component Callbacks (experimental)

--- a/apps/qwik-testing-library-e2e-library/package.json
+++ b/apps/qwik-testing-library-e2e-library/package.json
@@ -31,7 +31,7 @@
     "fmt.check": "prettier --check .",
     "lint": "eslint \"src/**/*.ts*\"",
     "start": "vite --open --mode ssr",
-    "test": "vitest run components",
+    "test": "vitest run",
     "validate": "pnpm test",
     "qwik": "qwik"
   },

--- a/apps/qwik-testing-library-e2e-library/src/hooks/render-hook.spec.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/hooks/render-hook.spec.tsx
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from "@noma.to/qwik-testing-library";
+import {
+  component$,
+  Slot,
+  useContextProvider,
+  useSignal,
+  useStore,
+} from "@builder.io/qwik";
+import { useCounter } from "./use-counter";
+import { useStoreValue } from "./use-store-value";
+import { useDoubled } from "./use-doubled";
+import { useDerived } from "./use-derived";
+import { ThemeContext, useTheme } from "./use-theme";
+
+describe("renderHook", () => {
+  it("should return the hook result and unmount function", async () => {
+    function useSetup() {
+      return useSignal(0);
+    }
+
+    const { result, unmount } = await renderHook(useSetup);
+
+    expect(result.value).toBe(0);
+    expect(unmount).toBeTypeOf("function");
+  });
+
+  it("should return a reactive result", async () => {
+    const { result } = await renderHook(useCounter);
+
+    await result.increment$();
+
+    expect(result.count.value).toBe(1);
+  });
+
+  it("should provide context via wrapper", async () => {
+    const ThemeProvider = component$(() => {
+      useContextProvider(ThemeContext, useStore({ mode: "dark" }));
+      return <Slot />;
+    });
+
+    const { result } = await renderHook(useTheme, {
+      wrapper: ThemeProvider,
+    });
+
+    expect(result.mode).toBe("dark");
+  });
+
+  describe("works with common hook patterns", () => {
+    it("store-based hook", async () => {
+      function useSetup() {
+        return useStoreValue({ first: "foo", second: "bar" });
+      }
+
+      const { result } = await renderHook(useSetup);
+
+      expect(result.first).toBe("foo");
+
+      result.first = "baz";
+
+      expect(result.first).toBe("baz");
+    });
+
+    it("computed-based hook", async () => {
+      function useCounterWithDoubled() {
+        const count = useSignal(1);
+        const doubled = useDoubled(count);
+        return { count, doubled };
+      }
+
+      const { result } = await renderHook(useCounterWithDoubled);
+
+      expect(result.doubled.value).toBe(2);
+
+      result.count.value = 5;
+
+      await waitFor(() => expect(result.doubled.value).toBe(10));
+    });
+
+    it("task-based hook", async () => {
+      function useInputWithDerived() {
+        const input = useSignal(0);
+        const derived = useDerived(input);
+        return { input, derived };
+      }
+
+      const { result } = await renderHook(useInputWithDerived);
+
+      expect(result.derived.value).toBe("derived-0");
+
+      result.input.value = 42;
+
+      await waitFor(() => expect(result.derived.value).toBe("derived-42"));
+    });
+  });
+});

--- a/apps/qwik-testing-library-e2e-library/src/hooks/use-counter.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/hooks/use-counter.tsx
@@ -1,0 +1,8 @@
+import { $, useSignal } from "@builder.io/qwik";
+
+export function useCounter(initial = 0) {
+  const count = useSignal(initial);
+  const increment$ = $(() => count.value++);
+
+  return { count, increment$ };
+}

--- a/apps/qwik-testing-library-e2e-library/src/hooks/use-derived.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/hooks/use-derived.tsx
@@ -1,0 +1,12 @@
+import { type Signal, useSignal, useTask$ } from "@builder.io/qwik";
+
+export function useDerived(source: Signal<number>) {
+  const derived = useSignal<string>();
+
+  useTask$(({ track }) => {
+    const value = track(source);
+    derived.value = "derived-" + value;
+  });
+
+  return derived;
+}

--- a/apps/qwik-testing-library-e2e-library/src/hooks/use-doubled.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/hooks/use-doubled.tsx
@@ -1,0 +1,5 @@
+import { type Signal, useComputed$ } from "@builder.io/qwik";
+
+export function useDoubled(source: Signal<number>) {
+  return useComputed$(() => source.value * 2);
+}

--- a/apps/qwik-testing-library-e2e-library/src/hooks/use-store-value.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/hooks/use-store-value.tsx
@@ -1,0 +1,5 @@
+import { useStore } from "@builder.io/qwik";
+
+export function useStoreValue<T extends Record<string, unknown>>(initial: T) {
+  return useStore(initial);
+}

--- a/apps/qwik-testing-library-e2e-library/src/hooks/use-theme.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/hooks/use-theme.tsx
@@ -1,0 +1,7 @@
+import { createContextId, useContext } from "@builder.io/qwik";
+
+export const ThemeContext = createContextId<{ mode: string }>("theme");
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/packages/qwik-testing-library/src/lib/qwik-testing-library.tsx
+++ b/packages/qwik-testing-library/src/lib/qwik-testing-library.tsx
@@ -1,7 +1,13 @@
 import { getQueriesForElement, prettyDOM } from "@testing-library/dom";
 import type { JSXOutput } from "@builder.io/qwik";
 import { getQwikLoaderScript } from "@builder.io/qwik/server";
-import type { ComponentRef, Options, Result } from "./types";
+import type {
+  ComponentRef,
+  RenderOptions,
+  RenderHookOptions,
+  RenderHookResult,
+  Result,
+} from "./types";
 
 // Patch HTMLTemplateElement.childNodes for happy-dom compatibility
 //
@@ -43,7 +49,7 @@ if (typeof process === "undefined" || !process.env?.QTL_SKIP_AUTO_CLEANUP) {
 
 const mountedContainers = new Set<ComponentRef>();
 
-async function render(ui: JSXOutput, options: Options = {}): Promise<Result> {
+async function render(ui: JSXOutput, options: RenderOptions = {}): Promise<Result> {
   const qwik = await import("@builder.io/qwik");
 
   let { container, baseElement = container, wrapper: Wrapper } = options;
@@ -114,5 +120,25 @@ function cleanup() {
   mountedContainers.forEach(cleanupAtContainer);
 }
 
+async function renderHook<Result>(
+  callback: () => Result,
+  options: RenderHookOptions = {},
+): Promise<RenderHookResult<Result>> {
+  const { component$ } = await import("@builder.io/qwik");
+
+  let hookResult: Result;
+
+  const TestComponent = component$(() => {
+    hookResult = callback();
+    return <></>;
+  });
+
+  const { unmount } = await render(<TestComponent />, {
+    wrapper: options.wrapper,
+  });
+
+  return { result: hookResult!, unmount };
+}
+
 export * from "@testing-library/dom";
-export { cleanup, render };
+export { cleanup, render, renderHook };

--- a/packages/qwik-testing-library/src/lib/types.ts
+++ b/packages/qwik-testing-library/src/lib/types.ts
@@ -4,9 +4,9 @@ import type {
   Queries,
 } from "@testing-library/dom";
 import { queries } from "@testing-library/dom";
-import type { Component, RenderOptions } from "@builder.io/qwik";
+import type { Component, RenderOptions as QwikRenderOptions } from "@builder.io/qwik";
 
-export interface Options extends RenderOptions {
+export interface RenderOptions extends QwikRenderOptions {
   container?: HTMLElement;
   baseElement?: HTMLElement;
   queries?: Queries & typeof queries;
@@ -31,3 +31,10 @@ export type ComponentRef = {
   container: HTMLElement;
   componentCleanup: () => void;
 };
+
+export type RenderHookOptions = Pick<RenderOptions, 'wrapper'>;
+
+export interface RenderHookResult<Result> {
+  result: Result;
+  unmount: () => void;
+}


### PR DESCRIPTION
Adds renderHook() to test Qwik hooks without manually creating wrapper components. The function runs the callback inside a component$(), reuses the existing render/cleanup infrastructure, and supports context via the wrapper option.

API: `renderHook(callback, options?) => { result, unmount }`
- result is returned directly (no .current indirection) since Qwik signals are stable reactive references
- wrapper option uses Slot, same pattern as render()
- cleanup is automatic via afterEach, consistent with render()

Includes documentation in README (marked experimental), consumer tests covering signals, stores, computed values, tasks, and context injection.

Also fixes a missing await in qwik-render.spec.tsx and removes the brittle path filter from the e2e-library test script.

Closes #9 