### PR TITLE
fix: resolve mock$() sharing same vi.fn() instance across calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,17 @@ jobs:
       - name: 🏗️ Build packages
         run: pnpm build
 
+      - name: 🏷️ Set preview versions
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          for pkg in ./packages/qwik-testing-library ./packages/qwik-mock; do
+            cd "$pkg"
+            jq --arg v "0.0.0-preview.$SHA" '.version = $v' package.json > tmp && mv tmp package.json
+            cd "$GITHUB_WORKSPACE"
+          done
+
       - name: 📦 Publish preview packages
-        run: pnpm dlx pkg-pr-new publish --compact ./packages/qwik-testing-library ./packages/qwik-mock
+        run: pnpm dlx pkg-pr-new publish --compact --commentWithSha --commentWithDev --packageManager=npm,pnpm,yarn ./packages/qwik-testing-library ./packages/qwik-mock
 
   release:
     name: Release

--- a/apps/qwik-testing-library-e2e-library/src/components/mocks/dual-action.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/components/mocks/dual-action.tsx
@@ -1,0 +1,17 @@
+import { component$, type QRL } from "@builder.io/qwik";
+
+interface DualActionProps {
+  onPrimary$: QRL<() => void>;
+  onSecondary$: QRL<() => void>;
+}
+
+export const DualAction = component$<DualActionProps>(
+  ({ onPrimary$, onSecondary$ }) => {
+    return (
+      <div>
+        <button onClick$={onPrimary$}>Primary</button>
+        <button onClick$={onSecondary$}>Secondary</button>
+      </div>
+    );
+  },
+);

--- a/apps/qwik-testing-library-e2e-library/src/components/mocks/mock.spec.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/components/mocks/mock.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from "@noma.to/qwik-testing-library";
+import { clearAllMocks, mock$ } from "@noma.to/qwik-mock";
+import { userEvent } from "@testing-library/user-event";
+import { DualAction } from "./dual-action";
+
+describe("mock$", () => {
+  beforeEach(() => {
+    clearAllMocks();
+  });
+
+  describe("independent mock identity", () => {
+    it("should resolve to different vi.fn() instances", async () => {
+      const mockA = mock$(() => {});
+      const mockB = mock$(() => {});
+
+      const resolvedA = await mockA.resolve();
+      const resolvedB = await mockB.resolve();
+
+      expect(resolvedA).not.toBe(resolvedB);
+    });
+
+    it("should track calls independently when using multiple mocks", async () => {
+      const onPrimaryMock = mock$(() => {});
+      const onSecondaryMock = mock$(() => {});
+      const user = userEvent.setup();
+
+      await render(
+        <DualAction
+          onPrimary$={onPrimaryMock}
+          onSecondary$={onSecondaryMock}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Primary" }));
+
+      await waitFor(() =>
+        expect(onPrimaryMock.resolve()).resolves.toHaveBeenCalledTimes(1),
+      );
+      expect(await onSecondaryMock.resolve()).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/qwik-testing-library-e2e-library/src/components/qwik-core/qwik-render.spec.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/components/qwik-core/qwik-render.spec.tsx
@@ -30,6 +30,6 @@ describe("<QwikRender />", () => {
   it("should render a list of elements", async () => {
     await render(<QwikRender items={["a", "b", "c"]} />);
 
-    expect(screen.findAllByRole("listitem")).resolves.toHaveLength(3);
+    await expect(screen.findAllByRole("listitem")).resolves.toHaveLength(3);
   });
 });

--- a/packages/qwik-mock/package.json
+++ b/packages/qwik-mock/package.json
@@ -5,14 +5,13 @@
   "repository": "https://github.com/ianlet/qwik-testing-library",
   "homepage": "https://github.com/ianlet/qwik-testing-library",
   "license": "MIT",
-  "main": "./lib/index.qwik.mjs",
-  "qwik": "./lib/index.qwik.mjs",
+  "main": "./lib/index.mjs",
   "types": "./lib-types/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib-types/index.d.ts",
-      "import": "./lib/index.qwik.mjs",
-      "require": "./lib/index.qwik.cjs"
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.cjs"
     }
   },
   "files": [

--- a/packages/qwik-mock/src/lib/qwik-mock.ts
+++ b/packages/qwik-mock/src/lib/qwik-mock.ts
@@ -1,14 +1,10 @@
-import { type QRL, $, implicit$FirstArg } from "@builder.io/qwik";
+import { $, type QRL, implicit$FirstArg } from "@builder.io/qwik";
 import { type Mock, vi } from "vitest";
-
-export const mockQrl = (): QRL<Mock> => {
-  return $(vi.fn());
-};
 
 /**
  * @experimental
  *
- * Create a QRL mock that can be used in tests to verify interactions
+ * Create a QRL mock that can be used in tests to verify interactions.
  *
  * As Qwik is an async framework, you need to `resolve()` the mock before making your verifications.
  * And remember to clear the mocks before each test to start with a clean slate!
@@ -16,13 +12,12 @@ export const mockQrl = (): QRL<Mock> => {
  * @example
  * ```tsx
  * describe('<MyButton />', () => {
- *   const onClickMock = mock$(() => {});
- *
  *   beforeEach(() => {
  *     clearAllMocks();
  *   });
  *
  *   it('should call onClick$', async () => {
+ *     const onClickMock = mock$();
  *     await render(<MyButton onClick$={onClickMock} />);
  *
  *     await userEvent.click(screen.getByRole('button'));
@@ -32,6 +27,10 @@ export const mockQrl = (): QRL<Mock> => {
  * });
  * ```
  */
+export const mockQrl = (_callbackQrl: QRL<(...args: any[]) => any>): QRL<Mock> => {
+  return $(vi.fn());
+};
+
 export const mock$ = implicit$FirstArg(mockQrl);
 
 /**

--- a/packages/qwik-mock/vite.config.ts
+++ b/packages/qwik-mock/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from "vite";
 import pkg from "./package.json";
-import { qwikVite } from "@builder.io/qwik/optimizer";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 const { dependencies = {}, peerDependencies = {} } = pkg as any;
@@ -11,11 +10,13 @@ export default defineConfig(() => {
   return {
     build: {
       target: "es2020",
+      outDir: "lib",
+      minify: false,
       lib: {
         entry: "./src/index.ts",
         formats: ["es", "cjs"],
         fileName: (format, entryName) =>
-          `${entryName}.qwik.${format === "es" ? "mjs" : "cjs"}`,
+          `${entryName}.${format === "es" ? "mjs" : "cjs"}`,
       },
       rollupOptions: {
         output: {
@@ -30,6 +31,6 @@ export default defineConfig(() => {
         ],
       },
     },
-    plugins: [qwikVite(), tsconfigPaths()],
+    plugins: [tsconfigPaths()],
   };
 });

--- a/packages/qwik-testing-library/package.json
+++ b/packages/qwik-testing-library/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://github.com/ianlet/qwik-testing-library",
   "license": "MIT",
   "main": "./lib/index.qwik.mjs",
-  "qwik": "./lib/index.qwik.mjs",
   "types": "./lib-types/index.d.ts",
+  "qwik": "./lib/index.qwik.mjs",
   "exports": {
     ".": {
       "types": "./lib-types/index.d.ts",

--- a/packages/qwik-testing-library/vite.config.ts
+++ b/packages/qwik-testing-library/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from "vite";
 import pkg from "./package.json";
-import { qwikVite } from "@builder.io/qwik/optimizer";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 const { dependencies = {}, peerDependencies = {} } = pkg as any;
@@ -11,6 +10,8 @@ export default defineConfig(() => {
   return {
     build: {
       target: "es2020",
+      outDir: "lib",
+      minify: false,
       lib: {
         entry: ["./src/index.ts", "./src/setup.ts"],
         formats: ["es", "cjs"],
@@ -30,6 +31,6 @@ export default defineConfig(() => {
         ],
       },
     },
-    plugins: [qwikVite(), tsconfigPaths()],
+    plugins: [tsconfigPaths()],
   };
 });


### PR DESCRIPTION
Every `mock$()` call returned a `QRL` wrapping the same `vi.fn()` instance. The Qwik optimizer assigns symbols based on source location, so all `QRL`s created inside `mockQrl` received the same symbol and collapsed into a single shared mock.

Using `inlinedQrl` to assign unique symbols at runtime was not viable: the optimizer requires a string literal as its second argument (panics otherwise) and extracts the first argument out of its closure scope.

The fix is to output plain `.mjs`/`.cjs` instead of `.qwik.mjs`/`.qwik.cjs`. The `.qwik` extension signals the consumer's optimizer to re-process library code, which is unnecessary for test utilities. Without it, raw `$()` calls are preserved in the output and the test runtime creates `QRL`s with unique symbols at execution time. Each `mock$()` now gets its own independent `vi.fn()`.

Related to #6 