### PR TITLE
feat: proxy-based mock$ API for direct assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Here's an example on how to use the `mock$` function:
 // import qwik-testing methods
 import {render, screen, waitFor} from "@noma.to/qwik-testing-library";
 // import qwik-mock methods
-import {mock$, clearAllMock} from "@noma.to/qwik-mock";
+import {clearAllMocks, mock$} from "@noma.to/qwik-mock";
 // import the userEvent methods to interact with the DOM
 import {userEvent} from "@testing-library/user-event";
 
@@ -300,9 +300,7 @@ import {Counter} from "./counter";
 // describe the test suite
 describe("<Counter />", () => {
   // initialize a mock
-  // note: the empty callback is required but currently unused
-  const onChangeMock = mock$(() => {
-  });
+  const onChangeMock = mock$();
 
   // setup beforeEach block to run before each test
   beforeEach(() => {
@@ -325,13 +323,23 @@ describe("<Counter />", () => {
       await user.click(decrementBtn);
 
       // assert that the onChange$ callback was called with the right value
-      // note: QRLs are async in Qwik, so we need to resolve them to verify interactions
       await waitFor(() =>
-        expect(onChangeMock.resolve()).resolves.toHaveBeenCalledWith(-1),
+        expect(onChangeMock).toHaveBeenCalledWith(-1),
       );
     });
   });
 })
+```
+
+You can also provide a default implementation to `mock$`:
+
+```tsx
+const onSubmitMock = mock$(() => "success");
+
+await render(<SubmitForm onSubmit$={onSubmitMock} />);
+await user.click(screen.getByRole("button", { name: "Submit" }));
+
+expect(await screen.findByText("success")).toBeInTheDocument();
 ```
 
 ### Qwik City - `server$` calls

--- a/apps/qwik-testing-library-e2e-library/src/components/counter.spec.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/components/counter.spec.tsx
@@ -4,7 +4,7 @@ import { userEvent } from "@testing-library/user-event";
 import { Counter } from "./counter";
 
 describe("<Counter />", () => {
-  const onChangeMock = mock$(() => {});
+  const onChangeMock = mock$();
 
   beforeEach(() => {
     clearAllMocks();
@@ -35,7 +35,7 @@ describe("<Counter />", () => {
       await user.click(incrementBtn);
 
       await waitFor(() =>
-        expect(onChangeMock.resolve()).resolves.toHaveBeenCalledWith(1),
+        expect(onChangeMock).toHaveBeenCalledWith(1),
       );
     });
   });
@@ -59,7 +59,7 @@ describe("<Counter />", () => {
       await user.click(decrementBtn);
 
       await waitFor(() =>
-        expect(onChangeMock.resolve()).resolves.toHaveBeenCalledWith(-1),
+        expect(onChangeMock).toHaveBeenCalledWith(-1),
       );
     });
   });

--- a/apps/qwik-testing-library-e2e-library/src/components/mocks/mock.spec.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/components/mocks/mock.spec.tsx
@@ -2,26 +2,37 @@ import { render, screen, waitFor } from "@noma.to/qwik-testing-library";
 import { clearAllMocks, mock$ } from "@noma.to/qwik-mock";
 import { userEvent } from "@testing-library/user-event";
 import { DualAction } from "./dual-action";
+import { SubmitForm } from "./submit-form";
 
 describe("mock$", () => {
   beforeEach(() => {
     clearAllMocks();
   });
 
+  describe("custom implementation", () => {
+    it("should use the provided implementation", async () => {
+      const onSubmitMock = mock$(() => "success");
+      const user = userEvent.setup();
+
+      await render(<SubmitForm onSubmit$={onSubmitMock} />);
+      await user.click(screen.getByRole("button", { name: "Submit" }));
+
+      expect(await screen.findByText("success")).toBeInTheDocument();
+      expect(onSubmitMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("independent mock identity", () => {
-    it("should resolve to different vi.fn() instances", async () => {
-      const mockA = mock$(() => {});
-      const mockB = mock$(() => {});
+    it("should create different mock instances", () => {
+      const mockA = mock$();
+      const mockB = mock$();
 
-      const resolvedA = await mockA.resolve();
-      const resolvedB = await mockB.resolve();
-
-      expect(resolvedA).not.toBe(resolvedB);
+      expect(mockA).not.toBe(mockB);
     });
 
     it("should track calls independently when using multiple mocks", async () => {
-      const onPrimaryMock = mock$(() => {});
-      const onSecondaryMock = mock$(() => {});
+      const onPrimaryMock = mock$();
+      const onSecondaryMock = mock$();
       const user = userEvent.setup();
 
       await render(
@@ -34,9 +45,9 @@ describe("mock$", () => {
       await user.click(screen.getByRole("button", { name: "Primary" }));
 
       await waitFor(() =>
-        expect(onPrimaryMock.resolve()).resolves.toHaveBeenCalledTimes(1),
+        expect(onPrimaryMock).toHaveBeenCalledTimes(1),
       );
-      expect(await onSecondaryMock.resolve()).not.toHaveBeenCalled();
+      expect(onSecondaryMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/qwik-testing-library-e2e-library/src/components/mocks/submit-form.tsx
+++ b/apps/qwik-testing-library-e2e-library/src/components/mocks/submit-form.tsx
@@ -1,0 +1,20 @@
+import { $, component$, type QRL, useSignal } from "@builder.io/qwik";
+
+interface SubmitFormProps {
+  onSubmit$: QRL<() => string>;
+}
+
+export const SubmitForm = component$<SubmitFormProps>(({ onSubmit$ }) => {
+  const result = useSignal("");
+
+  const handleSubmit = $(async () => {
+    result.value = await onSubmit$();
+  });
+
+  return (
+    <div>
+      <button onClick$={handleSubmit}>Submit</button>
+      {result.value && <p>{result.value}</p>}
+    </div>
+  );
+});

--- a/packages/qwik-mock/src/index.ts
+++ b/packages/qwik-mock/src/index.ts
@@ -1,1 +1,2 @@
-export * from "./lib/qwik-mock";
+export { clearAllMocks, mock$, mockQrl } from "./lib/qwik-mock";
+export type { QrlMock } from "./lib/qwik-mock";

--- a/packages/qwik-mock/src/lib/qwik-mock.ts
+++ b/packages/qwik-mock/src/lib/qwik-mock.ts
@@ -1,41 +1,75 @@
-import { $, type QRL, implicit$FirstArg } from "@builder.io/qwik";
+import { $, type QRL } from "@builder.io/qwik";
 import { type Mock, vi } from "vitest";
+
+/**
+ * A mock that can be passed as a component callback prop (`onClick$`, `onChange$`, etc.)
+ * and asserted on directly with `expect()`.
+ */
+export type QrlMock<
+  T extends (...args: any[]) => any = (...args: any[]) => any,
+> = QRL<T> & Mock<T>;
+
+/** @internal Called by the Qwik optimizer — use {@link mock$} instead. */
+export function mockQrl<
+  T extends (...args: any[]) => any = (...args: any[]) => any,
+>(implQrl?: QRL<T>): QrlMock<T> {
+  const mockFn = vi.fn(implQrl?.resolved);
+
+  // The optimizer may lazy-load the implementation QRL, so .resolved
+  // might not be available yet. Resolve it async and set when ready.
+  if (implQrl && !mockFn.getMockImplementation()) {
+    implQrl
+      .resolve()
+      .then((impl) => (mockFn as Mock).mockImplementation(impl));
+  }
+
+  const qrl = $(mockFn);
+
+  return new Proxy(qrl, {
+    get(target, prop, receiver) {
+      if (!(prop in target) && prop in mockFn) {
+        const value = (mockFn as any)[prop];
+        return typeof value === "function" ? value.bind(mockFn) : value;
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+    has(target, prop) {
+      return Reflect.has(target, prop) || Reflect.has(mockFn, prop);
+    },
+  }) as unknown as QrlMock<T>;
+}
 
 /**
  * @experimental
  *
- * Create a QRL mock that can be used in tests to verify interactions.
+ * Create a mock for a component callback prop (`onClick$`, `onChange$`, etc.).
  *
- * As Qwik is an async framework, you need to `resolve()` the mock before making your verifications.
- * And remember to clear the mocks before each test to start with a clean slate!
+ * Pass it to a component like any other `$` prop, then assert on it directly —
+ * no need to resolve.
+ *
+ * @param impl - Optional implementation function for the mock.
  *
  * @example
  * ```tsx
- * describe('<MyButton />', () => {
- *   beforeEach(() => {
- *     clearAllMocks();
- *   });
+ * const onClickMock = mock$();
+ * await render(<MyButton onClick$={onClickMock} />);
  *
- *   it('should call onClick$', async () => {
- *     const onClickMock = mock$();
- *     await render(<MyButton onClick$={onClickMock} />);
+ * await userEvent.click(screen.getByRole('button'));
  *
- *     await userEvent.click(screen.getByRole('button'));
- *
- *     await waitFor(() => expect(onClickMock.resolve()).resolves.toHaveBeenCalled());
- *   });
- * });
+ * await waitFor(() => expect(onClickMock).toHaveBeenCalled());
  * ```
  */
-export const mockQrl = (_callbackQrl: QRL<(...args: any[]) => any>): QRL<Mock> => {
-  return $(vi.fn());
-};
-
-export const mock$ = implicit$FirstArg(mockQrl);
+export function mock$<
+  T extends (...args: any[]) => any = (...args: any[]) => any,
+>(impl?: T): QrlMock<T> {
+  return mockQrl(impl ? $(impl) : undefined);
+}
 
 /**
- * Will call `.mockClear()` on all spies. This will clear mock history, but not reset its implementation to the
- * default one.
+ * Clear mock history on all mocks created with {@link mock$}.
+ * Does not reset their implementation.
+ *
+ * Typically called in `beforeEach` to start each test with a clean slate.
  */
 export function clearAllMocks() {
   vi.clearAllMocks();


### PR DESCRIPTION
`mock$()` now returns a `Proxy` satisfying both `QRL` and `Mock` interfaces, enabling direct assertions without `.resolve()` and no-arg creation.

Related #6