### PR TITLE
fix(qwik-mock): externalize vitest from bundle

### DIFF
--- a/packages/qwik-mock/package.json
+++ b/packages/qwik-mock/package.json
@@ -47,6 +47,7 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
-    "@builder.io/qwik": ">= 1.12.0 < 2"
+    "@builder.io/qwik": ">= 1.12.0 < 2",
+    "vitest": ">= 3.0.0"
   }
 }


### PR DESCRIPTION
vitest was in devDependencies only, so the build bundled the entire vitest/chai dependency tree into lib/ (~1.5MB). Moving it to peerDependencies externalizes it and drops the package to ~24KB.