### PR TITLE
fix: add explicit rootDir to tsconfig for TypeScript 6 compatibility

### DIFF
--- a/apps/qwik-testing-library-e2e-library/tsconfig.json
+++ b/apps/qwik-testing-library-e2e-library/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "declaration": true,
     "declarationDir": "lib-types",
+    "rootDir": "src",
     "resolveJsonModule": true,
     "moduleResolution": "Bundler",
     "esModuleInterop": true,

--- a/packages/qwik-mock/tsconfig.json
+++ b/packages/qwik-mock/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "declaration": true,
     "declarationDir": "lib-types",
+    "rootDir": "src",
     "resolveJsonModule": true,
     "moduleResolution": "Bundler",
     "esModuleInterop": true,

--- a/packages/qwik-testing-library/tsconfig.json
+++ b/packages/qwik-testing-library/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "declaration": true,
     "declarationDir": "lib-types",
+    "rootDir": "src",
     "resolveJsonModule": true,
     "moduleResolution": "Bundler",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Adds explicit `rootDir: "src"` to `packages/qwik-mock/tsconfig.json` and `packages/qwik-testing-library/tsconfig.json`
- TypeScript 6 requires `rootDir` to be explicitly set when emitting declarations (TS5011), which was blocking the dependabot upgrade in #99

## Test plan
- [x] `pnpm build` passes locally
- [x] `pnpm validate` passes locally (lint + build + tests)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)