### PR TITLE
chore: remove husky in favor of local git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,0 @@
-BRANCH_NAME=$(git branch | grep '*' | sed 's/* //')
-if [[ $BRANCH_NAME =~ "no branch" ]]; then
-  echo "You are rebasing, skipping hook"
-  exit 0
-fi
-
-pnpm validate

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,7 +1,0 @@
-BRANCH_NAME=$(git branch | grep '*' | sed 's/* //')
-if [[ $BRANCH_NAME =~ "no branch" ]]; then
-  echo "You are rebasing, skipping hook"
-  exit 0
-fi
-
-exec < /dev/tty && pnpm exec cz --hook || true

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "contributors:generate": "all-contributors generate",
     "build": "pnpm --filter '{packages/**}' run build",
     "release:prepare": "pnpm --filter '{packages/**}' run build && cp README.md packages/qwik-testing-library/README.md && cp LICENSE packages/qwik-testing-library/LICENSE && cp LICENSE packages/qwik-mock/LICENSE",
-    "release": "pnpm --filter '{packages/**}' --workspace-concurrency=1 exec -- npx --no-install semantic-release -e semantic-release-monorepo",
-    "prepare": "husky"
+    "release": "pnpm --filter '{packages/**}' --workspace-concurrency=1 exec -- npx --no-install semantic-release -e semantic-release-monorepo"
   },
   "keywords": [
     "testing",
@@ -38,7 +37,6 @@
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",
     "doctoc": "^2.3.0",
-    "husky": "^9.1.7",
     "semantic-release": "^25.0.3",
     "semantic-release-monorepo": "^8.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       doctoc:
         specifier: ^2.3.0
         version: 2.3.0
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(typescript@5.9.3)
@@ -2739,11 +2736,6 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -7763,8 +7755,6 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
-
-  husky@9.1.7: {}
 
   iconv-lite@0.4.24:
     dependencies:


### PR DESCRIPTION
## Summary
- Removes husky and its `.husky/` directory
- Removes the `prepare` script that installed husky hooks
- Developers can set up their own local git hooks (e.g. `scute check commit-message`, `pnpm validate`)

## Test plan
- [x] `pnpm validate` passes locally
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)