### PR TITLE
fix: ignore @eslint/js major bumps until ESLint 10 migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,8 @@ updates:
     ignore:
       - dependency-name: "eslint"
         versions: [">=9"]
-      - dependency-name: "eslint-plugin-n"
-        versions: [">=17"]
-      - dependency-name: "eslint-plugin-promise"
-        versions: [">=7"]
+      - dependency-name: "@eslint/js"
+        versions: [">=10"]
 
   # Update GitHub Actions dependencies
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Adds `@eslint/js >= 10` to dependabot ignore list — it requires ESLint 10 which we haven't migrated to
- Removes stale ignores for `eslint-plugin-n` and `eslint-plugin-promise` (no longer in deps)
- This unblocks #101 after merging (dependabot will regenerate without the `@eslint/js` bump)

## Test plan
- [ ] CI passes
- [ ] Next dependabot PR no longer includes `@eslint/js` 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)