### PR TITLE
ci: add Qwik 1.19 to test matrix and run lint on latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         node: ["20", "22"]
-        qwik: ["1.12", "1.14.1", "1.15", "1.16", "1.17", "1.18"]
+        qwik: ["1.12", "1.14.1", "1.15", "1.16", "1.17", "1.18", "1.19"]
         dom: ["jsdom", "happy-dom"]
         check: ["test"]
         include:
-          - { node: "22", qwik: "1.18", check: "lint" }
+          - { node: "22", qwik: "1.19", check: "lint" }
 
     steps:
       - name: ⬇️ Checkout repo


### PR DESCRIPTION
## Summary
- Adds Qwik 1.19 to the CI test matrix
- Moves the lint job from Qwik 1.18 to 1.19 so it always runs on the latest supported version

Prerequisite for the ESLint 10 migration (`eslint-plugin-qwik` only supports ESLint 10 from 1.19.1+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)