### PR TITLE
fix: use noSerialize in renderHook to satisfy valid-lexical-scope

### DIFF
--- a/packages/qwik-testing-library/src/lib/qwik-testing-library.tsx
+++ b/packages/qwik-testing-library/src/lib/qwik-testing-library.tsx
@@ -125,12 +125,13 @@ async function renderHook<Result>(
   callback: () => Result,
   options: RenderHookOptions = {},
 ): Promise<RenderHookResult<Result>> {
-  const { component$ } = await import("@builder.io/qwik");
+  const { component$, noSerialize } = await import("@builder.io/qwik");
 
-  let hookResult: Result;
+  const callbackRef = noSerialize(callback);
+  const resultRef = noSerialize({ current: undefined as Result | undefined });
 
   const TestComponent = component$(() => {
-    hookResult = callback();
+    resultRef!.current = callbackRef!();
     return <></>;
   });
 
@@ -138,7 +139,7 @@ async function renderHook<Result>(
     wrapper: options.wrapper,
   });
 
-  return { result: hookResult!, unmount };
+  return { result: resultRef!.current as Result, unmount };
 }
 
 export * from "@testing-library/dom";


### PR DESCRIPTION
## Summary

- The `renderHook` `component$` closure captures a callback function and mutates an outer `let` — both `qwik/valid-lexical-scope` violations introduced after the ESLint 10 migration
- Wraps both with `noSerialize` to explicitly mark them as non-serializable, which is correct since this test component is never serialized/resumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)